### PR TITLE
Do not force listening port to 8181, closes #33

### DIFF
--- a/root/etc/services.d/headphones/run
+++ b/root/etc/services.d/headphones/run
@@ -1,5 +1,5 @@
 #!/usr/bin/with-contenv bash
 
 exec \
-	s6-setuidgid abc python /app/headphones/Headphones.py -p 8181 \
+	s6-setuidgid abc python /app/headphones/Headphones.py \
 	--datadir=/config


### PR DESCRIPTION
This change allows using Headphones builtin mechanism to set and use the
listening TCP port.

This is particularly useful when using macvlan networking as docker's "-p"
option for port redirection isn't functional in this case.

  root/etc/services.d/headphones/run | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)