### PR TITLE
Use Python 3.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ RUN \
  apk add --no-cache --virtual=build-dependencies \
 	g++ \
 	gcc \
+	git \
 	make && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	ffmpeg \
 	flac \
-	git \
 	mc \
 	python3 && \
  echo "**** compile shntool *** *" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ RUN \
  apk add --no-cache --virtual=build-dependencies \
 	g++ \
 	gcc \
-	git \
 	make && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	ffmpeg \
 	flac \
+	git \
 	mc \
 	python3 && \
  echo "**** compile shntool *** *" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine-python:3.11
+FROM ghcr.io/linuxserver/baseimage-alpine:3.15
 
 # set version label
 ARG BUILD_DATE
@@ -21,7 +21,9 @@ RUN \
  apk add --no-cache \
 	ffmpeg \
 	flac \
-	mc && \
+	git \
+	mc \
+	python3 && \
  echo "**** compile shntool *** *" && \
  mkdir -p \
 	/tmp/shntool && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -16,12 +16,12 @@ RUN \
  apk add --no-cache --virtual=build-dependencies \
 	g++ \
 	gcc \
+	git \
 	make && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	ffmpeg \
 	flac \
-	git \
 	mc \
 	python3 && \
  echo "**** compile shntool *** *" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine-python:arm64v8-3.11
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.15
 
 # set version label
 ARG BUILD_DATE
@@ -21,7 +21,9 @@ RUN \
  apk add --no-cache \
 	ffmpeg \
 	flac \
-	mc && \
+	git \
+	mc \
+	python3 && \
  echo "**** compile shntool *** *" && \
  mkdir -p \
 	/tmp/shntool && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -16,12 +16,12 @@ RUN \
  apk add --no-cache --virtual=build-dependencies \
 	g++ \
 	gcc \
-	git \
 	make && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	ffmpeg \
 	flac \
+	git \
 	mc \
 	python3 && \
  echo "**** compile shntool *** *" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine-python:arm32v7-3.11
+FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.15
 
 # set version label
 ARG BUILD_DATE
@@ -21,7 +21,9 @@ RUN \
  apk add --no-cache \
 	ffmpeg \
 	flac \
-	mc && \
+	git \
+	mc \
+	python3 && \
  echo "**** compile shntool *** *" && \
  mkdir -p \
 	/tmp/shntool && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -16,12 +16,12 @@ RUN \
  apk add --no-cache --virtual=build-dependencies \
 	g++ \
 	gcc \
+	git \
 	make && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	ffmpeg \
 	flac \
-	git \
 	mc \
 	python3 && \
  echo "**** compile shntool *** *" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -16,12 +16,12 @@ RUN \
  apk add --no-cache --virtual=build-dependencies \
 	g++ \
 	gcc \
-	git \
 	make && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	ffmpeg \
 	flac \
+	git \
 	mc \
 	python3 && \
  echo "**** compile shntool *** *" && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -79,6 +79,7 @@ app_setup_nginx_reverse_proxy_block: "Access WebUI at `<your-ip>:8181` and walk 
 # changelog
 
 changelogs:
+  - { date: "02.02.22:", desc: "Rebasing to alpine 3.15. Updating to Python 3." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }
   - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "09.05.19:", desc: "Add default UTC timezone if user does not set it." }

--- a/root/etc/services.d/headphones/run
+++ b/root/etc/services.d/headphones/run
@@ -1,5 +1,5 @@
 #!/usr/bin/with-contenv bash
 
 exec \
-	s6-setuidgid abc python /app/headphones/Headphones.py \
+	s6-setuidgid abc python3 /app/headphones/Headphones.py \
 	--datadir=/config


### PR DESCRIPTION
## Description:
Headphones recently merged Python 3 support to the master branch, breaking the existing images.

Update the Dockerfiles to use baseimage-alpine image and update the services to use Python 3.

## Benefits of this PR and context:
Headphones actually works again 😄 

## How Has This Been Tested?
Built the container and ran it on my existing headphones data.

I have not been able to test anything other than amd64 but the others should work.